### PR TITLE
Add an option to enable/disable crawling of pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,17 @@ Default value: ``
 
 You can define in this object some replace rules for the static html versions. Each value (String or RegExp) will be replace by the corresponding key. If you use String instead of RegExp only the first occurence will be replaced.
 
+#### options.urls
+Type: `Array`
+Default Value: `['']`
+
+This contains the list of initial URLs to crawl.
+
+#### options.crawl
+Type: `Boolean`
+Default Value: `true`
+
+If this value is set to `False` only the URLs mentioned in `options.urls` will be crawled and further links won't be crawled.
 
 ### Usage Examples
 

--- a/src/escaped-seo.coffee
+++ b/src/escaped-seo.coffee
@@ -94,7 +94,7 @@ module.exports = (grunt) ->
 					grunt.file.write(pf, content);
 					
 					pattern = /href=["']([#!\/]*[\w\/\-_]*)['"]/g
-					while (crawl and match = pattern.exec(content))
+					while (options.crawl and match = pattern.exec(content))
 						u = match[1]
 						if queue[u] is undefined and (u isnt "#" and u isnt "/" and u isnt "#/")
 							grunt.log.writeln('add link: '.yellow + u)

--- a/src/escaped-seo.coffee
+++ b/src/escaped-seo.coffee
@@ -19,6 +19,7 @@ module.exports = (grunt) ->
 			folder: 'seo'
 			changefreq: 'daily'
 			replace: {}
+			crawl: true
 
 		if !options.server? or options.server.length is 0
 			options.server = options.domain
@@ -93,7 +94,7 @@ module.exports = (grunt) ->
 					grunt.file.write(pf, content);
 					
 					pattern = /href=["']([#!\/]*[\w\/\-_]*)['"]/g
-					while (match = pattern.exec(content))
+					while (crawl and match = pattern.exec(content))
 						u = match[1]
 						if queue[u] is undefined and (u isnt "#" and u isnt "/" and u isnt "#/")
 							grunt.log.writeln('add link: '.yellow + u)

--- a/tasks/escaped-seo.js
+++ b/tasks/escaped-seo.js
@@ -15,7 +15,8 @@
         "public": 'dist',
         folder: 'seo',
         changefreq: 'daily',
-        replace: {}
+        replace: {},
+        crawl: true
       });
       if ((options.server == null) || options.server.length === 0) {
         options.server = options.domain;
@@ -109,7 +110,7 @@
               pf = path.join("./", options["public"], options.folder, destFile + ".html");
               grunt.file.write(pf, content);
               pattern = /href=["']([#!\/]*[\w\/\-_]*)['"]/g;
-              while ((match = pattern.exec(content))) {
+              while (options.crawl && (match = pattern.exec(content))) {
                 u = match[1];
                 if (queue[u] === void 0 && (u !== "#" && u !== "/" && u !== "#/")) {
                   grunt.log.writeln('add link: '.yellow + u);


### PR DESCRIPTION
In certain scenarios you just need a list of URLs to be crawled, so I have added a flag which disables crawling and only relies on `options.urls`.
